### PR TITLE
Support log4j2 log framework, needed for Storm 0.10.0

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,13 +11,29 @@ class storm::config inherits storm {
     require => [ Package['storm'], File[$log_dir], File[$local_dir] ],
   }
 
-  file { $logback:
+  if $logback {
+    $real_log_cluster_config = $logback
+  } elsif !$log_cluster_config {
+    $real_log_cluster_config = "/opt/storm/${log_framework}/cluster.xml"
+  } else {
+    $real_log_cluster_config = $log_cluster_config
+  }
+
+  if $logback_template {
+    $real_log_template = $logback_template
+  } elsif !$log_template {
+    $real_log_template = "storm/cluster.${log_framework}.xml.erb"
+  } else {
+    $real_log_template = $log_template
+  }
+
+  file { $real_log_cluster_config :
     ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
-    content => template($logback_template),
+    content => template($real_log_template),
     require => File[$config],
   }
-
+  
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,8 +21,11 @@ class storm(
   $local_dir               = $storm::params::local_dir,
   $local_hostname          = $storm::params::local_hostname,
   $log_dir                 = $storm::params::log_dir,
-  $logback                 = $storm::params::logback,
-  $logback_template        = $storm::params::logback_template,
+  $log_framework           = $storm::params::log_framework,
+  $log_cluster_config      = undef,
+  $log_template            = undef,
+  $logback                 = undef, # deprecated
+  $logback_template        = undef, # deprecated
   $logviewer_childopts     = $storm::params::logviewer_childopts,
   $nimbus_host             = $storm::params::nimbus_host,
   $nimbus_childopts        = $storm::params::nimbus_childopts,
@@ -72,8 +75,11 @@ class storm(
   validate_absolute_path($local_dir)
   validate_string($local_hostname)
   validate_absolute_path($log_dir)
-  validate_absolute_path($logback)
-  validate_string($logback_template)
+  validate_string($log_framework)
+  if $log_cluster_config { validate_absolute_path($log_cluster_config) }
+  if $log_template { validate_string($log_template) }
+  if $logback { validate_absolute_path($logback) }
+  if $logback_template { validate_string($logback_template) }
   validate_string($logviewer_childopts)
   validate_string($nimbus_host)
   validate_string($nimbus_childopts)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,9 +12,8 @@ class storm::params {
   $group_ensure            = 'present'
   $local_dir               = '/app/storm'
   $local_hostname          = $::hostname
+  $log_framework           = 'logback'
   $log_dir                 = '/var/log/storm'
-  $logback                 = '/opt/storm/logback/cluster.xml'
-  $logback_template        = 'storm/cluster.xml.erb'
   $logviewer_childopts     = '-Xmx128m -Djava.net.preferIPv4Stack=true'
   $nimbus_host             = 'nimbus1'
   $nimbus_childopts        = '-Xmx256m -Djava.net.preferIPv4Stack=true'

--- a/templates/cluster.log4j2.xml.erb
+++ b/templates/cluster.log4j2.xml.erb
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+###
+### This file is managed by Puppet.
+###
+-->
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<configuration monitorInterval="60">
+<properties>
+    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} [%p] %msg%n</property>
+    <property name="patternMetris">%d %-8r %m%n</property>
+</properties>
+<appenders>
+    <RollingFile name="A1"
+                 fileName="<%= @log_dir %>/${sys:logfile.name}"
+                 filePattern="<%= @log_dir %>/${sys:logfile.name}.%i">
+        <PatternLayout>
+            <pattern>${pattern}</pattern>
+        </PatternLayout>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
+        </Policies>
+        <DefaultRolloverStrategy max="9"/>
+    </RollingFile>
+    <RollingFile name="ACCESS"
+                 fileName="<%= @log_dir %>/access.log"
+                 filePattern="<%= @log_dir %>/access.log.%i">
+        <PatternLayout>
+            <pattern>${pattern}</pattern>
+        </PatternLayout>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
+        </Policies>
+        <DefaultRolloverStrategy max="9"/>
+    </RollingFile>
+    <RollingFile name="METRICS"
+                 fileName="<%= @log_dir %>/metrics.log"
+                 filePattern="<%= @log_dir %>/metrics.log.%i">
+        <PatternLayout>
+            <pattern>${patternMetris}</pattern>
+        </PatternLayout>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="2 MB"/> <!-- Or every 100 MB -->
+        </Policies>
+        <DefaultRolloverStrategy max="9"/>
+    </RollingFile>
+</appenders>
+<loggers>
+
+    <Logger name="backtype.storm.security.auth.authorizer" level="info">
+        <AppenderRef ref="ACCESS"/>
+    </Logger>
+    <Logger name="backtype.storm.metric.LoggingMetricsConsumer" level="info">
+        <AppenderRef ref="METRICS"/>
+    </Logger>
+    <root level="info"> <!-- We log everything -->
+        <appender-ref ref="A1"/>
+    </root>
+</loggers>
+</configuration>

--- a/templates/cluster.logback.xml.erb
+++ b/templates/cluster.logback.xml.erb
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<!--
+###
+### This file is managed by Puppet.
+###
+-->
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<configuration scan="true" scanPeriod="60 seconds">
+ <appender name="A1" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file><%= @log_dir %>/${logfile.name}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern><%= @log_dir %>/${logfile.name}.%i</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>9</maxIndex>
+    </rollingPolicy>
+
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>100MB</maxFileSize>
+    </triggeringPolicy>
+
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n</pattern>
+    </encoder>
+ </appender>
+
+ <appender name="ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file><%= @log_dir %>/access.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern><%= @log_dir %>/access.log.%i</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>9</maxIndex>
+    </rollingPolicy>
+
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>100MB</maxFileSize>
+    </triggeringPolicy>
+
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="METRICS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file><%= @log_dir %>/metrics.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern><%= @log_dir %>/metrics.log.%i</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>9</maxIndex>
+    </rollingPolicy>
+
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>2MB</maxFileSize>
+    </triggeringPolicy>
+
+    <encoder>
+      <pattern>%d %-8r %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="A1"/>
+  </root>
+
+  <logger name="backtype.storm.security.auth.authorizer" additivity="false">
+    <level value="INFO" />
+    <appender-ref ref="ACCESS" />
+  </logger>
+
+  <logger name="backtype.storm.metric.LoggingMetricsConsumer" additivity="false" >
+    <level value="INFO"/>
+    <appender-ref ref="METRICS"/>
+  </logger>
+
+</configuration>


### PR DESCRIPTION
In the Apache Storm 0.10.0, the logging framework has been changed from logback to log4j2.
This PR accommodates that change and make sure we are still backwards compatible
